### PR TITLE
Fix Chrome supported version

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Browser support is required to **view** server timings easily. Because server
 timings are sent as an HTTP header, there is no negative impact to sending
 the header to unsupported browsers.
 
-  * **Chrome 66 or higher** is required to properly display server timings
+  * **Chrome 65 or higher** is required to properly display server timings
     in the devtools.
 
   * **Firefox is pending** with an [open bug report (ID 1403051)](https://bugzilla.mozilla.org/show_bug.cgi?id=1403051)


### PR DESCRIPTION
It seems Chrome 65 supports ServerTiming API.
Ref: https://blog.chromium.org/2018/02/chrome-65-beta-css-paint-api-and.html