### PR TITLE
added StopUnlessStopped, an idempotent Stop

### DIFF
--- a/metric.go
+++ b/metric.go
@@ -87,6 +87,17 @@ func (m *Metric) Stop() *Metric {
 	return m
 }
 
+// StopUnlessStopped calls Stop only if Stop has not already been called.
+// This can be useful if you need to make sure Stop is called and don't
+// want to replace an exiting Duration value. You might want this in a
+// defer function where you don't want to add Stop on each exceptional exit.
+func (m *Metric) StopUnlessStopped() *Metric {
+	if m.Duration == 0 {
+		m.Stop()
+	}
+	return m
+}
+
 // String returns the valid Server-Timing metric entry value.
 func (m *Metric) String() string {
 	// Begin building parts, expected capacity is length of extra

--- a/metric_test.go
+++ b/metric_test.go
@@ -32,3 +32,25 @@ func TestMetric_stopNoStart(t *testing.T) {
 		t.Fatal("duration should not be set")
 	}
 }
+
+func TestMetric_startStopUnlessStopped(t *testing.T) {
+	var m Metric
+	m.Start()
+	time.Sleep(50 * time.Millisecond)
+	m.Stop()
+
+	d1 := m.Duration
+	time.Sleep(50 * time.Millisecond)
+	m.StopUnlessStopped()
+	d2 := m.Duration
+	time.Sleep(50 * time.Millisecond)
+	m.Stop()
+	d3 := m.Duration
+
+	if d1 != d2 {
+		t.Fatal("duration should not have been reset")
+	}
+	if d1 == d3 {
+		t.Fatal("duration should have been reset")
+	}
+}


### PR DESCRIPTION
This is for when you want to call Stop but not if Stop was already called.

I've got some situations where I want to start a timer then there's many lines of thing that may exit the function early or may make it to where I've got the Stop I really care about.

Adding this in a defer at the top makes sure we do get a Stop if we had to exit early but don't trample on the one we care about.