### PR TITLE
Fix number regex

### DIFF
--- a/header.go
+++ b/header.go
@@ -118,7 +118,7 @@ func headerParams(s string) (http.Header, string) {
 	}), key
 }
 
-var reNumber = regexp.MustCompile(`\d+`)
+var reNumber = regexp.MustCompile(`^\d+\.?\d*$`)
 
 // headerEncodeParam encodes a key/value pair as a proper `key=value`
 // syntax, using double-quotes if necessary.

--- a/header.go
+++ b/header.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -59,11 +58,8 @@ func ParseHeader(input string) (*Header, error) {
 		// is what modern browsers are treating it as. If the parsing of
 		// an integer fails, the set value remains in the Extra field.
 		if v, ok := m.Extra[paramNameDur]; ok {
-			intv, err := strconv.Atoi(v)
-			if err == nil {
-				m.Duration = time.Duration(intv) * time.Millisecond
-				delete(m.Extra, paramNameDur)
-			}
+			m.Duration, _ = time.ParseDuration(v + "ms")
+			delete(m.Extra, paramNameDur)
 		}
 
 		metrics = append(metrics, &m)

--- a/header_test.go
+++ b/header_test.go
@@ -50,6 +50,32 @@ var headerCases = []struct {
 		},
 		`sql-1;desc="MySQL; lookup Server";dur=100`,
 	},
+
+	// Description that contains a number
+	{
+		[]*Metric{
+			{
+				Name:     "sql-1",
+				Duration: 100 * time.Millisecond,
+				Desc:     "GET 200",
+				Extra:    map[string]string{},
+			},
+		},
+		`sql-1;desc="GET 200";dur=100`,
+	},
+
+	// Number that contains floating point
+	{
+		[]*Metric{
+			{
+				Name:     "sql-1",
+				Duration: 100100 * time.Microsecond,
+				Desc:     "MySQL; lookup Server",
+				Extra:    map[string]string{},
+			},
+		},
+		`sql-1;desc="MySQL; lookup Server";dur=100.1`,
+	},
 }
 
 func TestParseHeader(t *testing.T) {


### PR DESCRIPTION
In case that a string contains a number, it is considered as a number and not quoted.
This fix fixes the regex to match numbers and floating point numbers