### PR TITLE
Increment metric duration

### DIFF
--- a/header.go
+++ b/header.go
@@ -70,6 +70,12 @@ func ParseHeader(input string) (*Header, error) {
 
 // NewMetric creates a new Metric and adds it to this header.
 func (h *Header) NewMetric(name string) *Metric {
+	for i := range h.Metrics {
+		if h.Metrics[i].Name == name {
+			return h.Metrics[i]
+		}
+	}
+
 	return h.Add(&Metric{Name: name})
 }
 

--- a/metric.go
+++ b/metric.go
@@ -81,7 +81,7 @@ func (m *Metric) Start() *Metric {
 func (m *Metric) Stop() *Metric {
 	// Only record if we have a start time set with Start()
 	if !m.startTime.IsZero() {
-		m.Duration = time.Since(m.startTime)
+		m.Duration += time.Since(m.startTime)
 	}
 
 	return m


### PR DESCRIPTION
This change allows for incrementing the metric duration.
Good use case for aggregating compute duration for specific methods in a recursive environment. Which is what I use it for.


``` go
func recusiveThing(ctx context.Context, id string) {
    //... many other compute

    timing := servertiming.FromContext(ctx)

    dt := timing.NewMetric("some_compute").Start()
    doSomeComputeForThisThing(ctx, id)
    dt.End()

    subThings := findSubThingsForThisThing(ctx, id)
    for i := range subThings {
        recursiveThing(ctx, subThings[i].id)
    }
}

// how much time did we spend with doSomeComputeForThisThing in total?

```

Please consider if you want to alter the functionality before merging, as it may be a breaking change for some who rely upon the current implementation logic.